### PR TITLE
fix(hasNativeMethod): 支持 type 判断 (close: #12)

### DIFF
--- a/library/src/main/ets/entity/BaseBridge.ts
+++ b/library/src/main/ets/entity/BaseBridge.ts
@@ -247,7 +247,7 @@ export class BaseBridge implements JsInterface, IBaseBridge {
     try {
       const p: {
         name: string,
-        type
+        type: 'syn' | 'asyn' | 'all'
       } = JSON.parse(param);
       const m = this.parseNamespace(p.name)
       let methodName = m[1]
@@ -264,7 +264,8 @@ export class BaseBridge implements JsInterface, IBaseBridge {
             const err = `call failed: please add @JavaScriptInterface decorator in the ${methodName} method`
             result.msg = err
           } else {
-            result.code = 0
+            const async = <boolean> Reflect.getMetadata(MetaData.ASYNC, method)?? false
+            result.code = (async && p.type==='syn') || (!async && p.type==='asyn') ? 1 : 0
           }
         } else {
           const err = `call failed: ${methodName} native method does not exist`


### PR DESCRIPTION
我是提出 issue #12 的同事，经排查，发现是因为我们这边之前是先用 hasNativeMethod 判断方法是同步还是异步再去走不同调用逻辑的，而鸿蒙这边目前 hasNativeMethod 没有实现 type 判断，导致方法都被判定为了 syn，即同步，导致 #12 所说的异步失效，该 pr 实现了 type 判断，对齐了其他端实现。