### PR TITLE
fix: do not hang when hasJavascriptMethod JS never responds

### DIFF
--- a/library/src/main/ets/core/BaseBridge.ts
+++ b/library/src/main/ets/core/BaseBridge.ts
@@ -19,6 +19,7 @@ import { LogUtils } from '../utils/LogUtils'
 import router from '@ohos.router'
 import { IBaseBridge, IWebViewControllerProxy } from './WebViewInterface'
 import { ToastUtils } from '../utils/ToastUtils'
+import { resolveHasJavascriptMethod } from '../utils/HasJavascriptMethodHelper'
 import { JSON } from '@kit.ArkTS'
 
 export class BaseBridge implements JsInterface, IBaseBridge {
@@ -284,14 +285,10 @@ export class BaseBridge implements JsInterface, IBaseBridge {
   }
 
   hasJavascriptMethod(method: string): Promise<boolean> {
-    if (this.checkIfDS2()) {
-      return
-    }
-    return new Promise((resolve, reject) => {
-      let handler: OnReturnValue = (has: boolean) => {
-        resolve(has)
-      }
-      this.callHandler("_hasJavascriptMethod", [method], handler)
+    // DS2 does not support this probe; always return false instead of undefined.
+    // If the page has no dsbridge, JS never calls back — resolve false instead of hanging.
+    return resolveHasJavascriptMethod(this.checkIfDS2(), (onResult) => {
+      this.callHandler("_hasJavascriptMethod", [method], onResult)
     })
   }
 

--- a/library/src/main/ets/utils/HasJavascriptMethodHelper.ts
+++ b/library/src/main/ets/utils/HasJavascriptMethodHelper.ts
@@ -1,0 +1,34 @@
+/**
+ * Promise helper for hasJavascriptMethod.
+ * Do not hang when JS never responds; resolve false instead of deadlock.
+ */
+export const HAS_JAVASCRIPT_METHOD_TIMEOUT_MS = 300
+
+export type HasJavascriptMethodInvoker = (onResult: (has: boolean) => void) => void
+
+export function resolveHasJavascriptMethod(
+  isDS2: boolean,
+  invoke: HasJavascriptMethodInvoker,
+  timeoutMs: number = HAS_JAVASCRIPT_METHOD_TIMEOUT_MS
+): Promise<boolean> {
+  if (isDS2) {
+    return Promise.resolve(false)
+  }
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (value: boolean) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(value)
+    }
+    const timer = setTimeout(() => {
+      finish(false)
+    }, timeoutMs)
+    invoke((has: boolean) => {
+      finish(has)
+    })
+  })
+}

--- a/test/hasJavascriptMethodHelper.mjs
+++ b/test/hasJavascriptMethodHelper.mjs
@@ -1,0 +1,35 @@
+/**
+ * Extracted host-side helper mirroring
+ * library/src/main/ets/utils/HasJavascriptMethodHelper.ts
+ *
+ * Do not hang when JS never responds; hasJavascriptMethod should return false,
+ * not deadlock.
+ */
+export const HAS_JAVASCRIPT_METHOD_TIMEOUT_MS = 300
+
+export function resolveHasJavascriptMethod(
+  isDS2,
+  invoke,
+  timeoutMs = HAS_JAVASCRIPT_METHOD_TIMEOUT_MS
+) {
+  if (isDS2) {
+    return Promise.resolve(false)
+  }
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (value) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(value)
+    }
+    const timer = setTimeout(() => {
+      finish(false)
+    }, timeoutMs)
+    invoke((has) => {
+      finish(has)
+    })
+  })
+}

--- a/test/hasJavascriptMethodHelper.test.mjs
+++ b/test/hasJavascriptMethodHelper.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  HAS_JAVASCRIPT_METHOD_TIMEOUT_MS,
+  resolveHasJavascriptMethod
+} from './hasJavascriptMethodHelper.mjs'
+
+describe('resolveHasJavascriptMethod', () => {
+  it('returns false immediately when DS2 is enabled (no undefined)', async () => {
+    let invoked = false
+    const result = await resolveHasJavascriptMethod(true, () => {
+      invoked = true
+    })
+    assert.equal(result, false)
+    assert.equal(invoked, false)
+  })
+
+  it('resolves with the JS callback value and clears the timeout', async () => {
+    const result = await resolveHasJavascriptMethod(false, (onResult) => {
+      onResult(true)
+    }, 200)
+    assert.equal(result, true)
+  })
+
+  it('does not hang when JS never responds; resolves false after timeout', async () => {
+    const started = Date.now()
+    const result = await resolveHasJavascriptMethod(false, () => {
+      // no callback — page without dsbridge
+    }, 200)
+    const elapsed = Date.now() - started
+    assert.equal(result, false)
+    assert.ok(elapsed >= 200, `expected timeout wait, elapsed=${elapsed}`)
+    assert.ok(elapsed < 1000, `should not deadlock, elapsed=${elapsed}`)
+  })
+
+  it('ignores a late JS callback after timeout has already resolved false', async () => {
+    let lateCallback
+    const result = await resolveHasJavascriptMethod(false, (onResult) => {
+      lateCallback = onResult
+    }, 200)
+    assert.equal(result, false)
+    lateCallback(true)
+    assert.equal(result, false)
+  })
+
+  it('uses the default 200–500ms timeout', () => {
+    assert.ok(HAS_JAVASCRIPT_METHOD_TIMEOUT_MS >= 200)
+    assert.ok(HAS_JAVASCRIPT_METHOD_TIMEOUT_MS <= 500)
+  })
+})


### PR DESCRIPTION
Fixes #30

Pages without dsbridge never call back, so await hasJavascriptMethod deadlocked. Return false for DS2 and after a short timeout instead of hanging.

Host test: node --test test/hasJavascriptMethodHelper.test.mjs. No device.

Signed-off-by: Tony Coder <407243179@qq.com>