### PR TITLE
fix: catch sync native throws and return error payload

### DIFF
--- a/library/src/main/ets/core/BaseBridge.ts
+++ b/library/src/main/ets/core/BaseBridge.ts
@@ -19,6 +19,7 @@ import { LogUtils } from '../utils/LogUtils'
 import router from '@ohos.router'
 import { IBaseBridge, IWebViewControllerProxy } from './WebViewInterface'
 import { ToastUtils } from '../utils/ToastUtils'
+import { invokeSyncNativeMethod } from '../utils/SyncCallHelper'
 import { JSON } from '@kit.ArkTS'
 
 export class BaseBridge implements JsInterface, IBaseBridge {
@@ -190,9 +191,14 @@ export class BaseBridge implements JsInterface, IBaseBridge {
       }
 
     } else {
-      const r = method.call(obj, data);
+      // Sync throws must not escape the bridge (WebView/JS crash).
+      // Android DSBridge catches method.invoke and returns an error payload.
+      const invoked = invokeSyncNativeMethod(method, obj, data)
+      if (invoked.code !== 0) {
+        return this.handlerError(result, invoked.errMsg ?? '')
+      }
       result.code = 0
-      result.data = r
+      result.data = invoked.data
     }
 
     return this._isSupportDS2 ? result.data?.toString() : JSON.stringify(result)

--- a/library/src/main/ets/utils/SyncCallHelper.ts
+++ b/library/src/main/ets/utils/SyncCallHelper.ts
@@ -1,0 +1,25 @@
+/**
+ * Sync native method invoke.
+ *
+ * A throw from a @JavaScriptInterface method must become an error payload,
+ * matching Android DSBridge (method.invoke is caught) and the async call()
+ * branch. An uncaught throw escapes the bridge and can crash WebView/JS.
+ */
+export interface SyncNativeCallOutcome {
+  code: number
+  data?: Object | string | number | boolean
+  errMsg?: string
+}
+
+/**
+ * Invoke a sync native method. Never rethrows; failures use code -1 + errMsg.
+ */
+export function invokeSyncNativeMethod(method: Function, obj: Object, data: string): SyncNativeCallOutcome {
+  try {
+    const r = method.call(obj, data)
+    return { code: 0, data: r }
+  } catch (e) {
+    // Same stringify as the async call() catch → handlerError path.
+    return { code: -1, errMsg: JSON.stringify(e) }
+  }
+}

--- a/test/syncCallHelper.mjs
+++ b/test/syncCallHelper.mjs
@@ -1,0 +1,39 @@
+/**
+ * Extracted host-side helper mirroring
+ * library/src/main/ets/utils/SyncCallHelper.ts
+ *
+ * Sync native throws must become an error payload (code -1 + errMsg),
+ * not escape the bridge. Matches async call() catch → handlerError and
+ * Android DSBridge method.invoke catch.
+ */
+
+export function invokeSyncNativeMethod(method, obj, data) {
+  try {
+    const r = method.call(obj, data)
+    return { code: 0, data: r }
+  } catch (e) {
+    return { code: -1, errMsg: JSON.stringify(e) }
+  }
+}
+
+/**
+ * Mirrors BaseBridge.handlerError JSON payload (code stays -1).
+ */
+export function handlerError(result, err) {
+  result.errMsg = err
+  return JSON.stringify(result)
+}
+
+/**
+ * Mirrors BaseBridge.call() sync branch after method lookup.
+ */
+export function callSync(method, obj, data) {
+  const result = { code: -1 }
+  const invoked = invokeSyncNativeMethod(method, obj, data)
+  if (invoked.code !== 0) {
+    return handlerError(result, invoked.errMsg ?? '')
+  }
+  result.code = 0
+  result.data = invoked.data
+  return JSON.stringify(result)
+}

--- a/test/syncCallHelper.test.mjs
+++ b/test/syncCallHelper.test.mjs
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  invokeSyncNativeMethod,
+  handlerError,
+  callSync
+} from './syncCallHelper.mjs'
+
+describe('invokeSyncNativeMethod / callSync error payload', () => {
+  it('returns code 0 and data when the sync method succeeds', () => {
+    const obj = {
+      ping(data) {
+        return `ok:${data}`
+      }
+    }
+    const invoked = invokeSyncNativeMethod(obj.ping, obj, 'hello')
+    assert.equal(invoked.code, 0)
+    assert.equal(invoked.data, 'ok:hello')
+    assert.equal(invoked.errMsg, undefined)
+
+    const payload = JSON.parse(callSync(obj.ping, obj, 'hello'))
+    assert.equal(payload.code, 0)
+    assert.equal(payload.data, 'ok:hello')
+    assert.equal(payload.errMsg, undefined)
+  })
+
+  it('turns a thrown Error into handlerError payload and does not rethrow', () => {
+    const obj = {
+      boom() {
+        throw new Error('native failed')
+      }
+    }
+    assert.doesNotThrow(() => invokeSyncNativeMethod(obj.boom, obj, '{}'))
+
+    const invoked = invokeSyncNativeMethod(obj.boom, obj, '{}')
+    assert.equal(invoked.code, -1)
+    assert.equal(invoked.errMsg, JSON.stringify(new Error('native failed')))
+
+    const raw = callSync(obj.boom, obj, '{}')
+    const payload = JSON.parse(raw)
+    assert.equal(payload.code, -1)
+    assert.equal(payload.errMsg, JSON.stringify(new Error('native failed')))
+    assert.equal(payload.data, undefined)
+  })
+
+  it('turns a thrown object into handlerError payload like async call() catch', () => {
+    const err = { message: 'permission denied', code: 403 }
+    const obj = {
+      deny() {
+        throw err
+      }
+    }
+    const invoked = invokeSyncNativeMethod(obj.deny, obj, '{}')
+    assert.equal(invoked.code, -1)
+    assert.equal(invoked.errMsg, JSON.stringify(err))
+
+    const payload = JSON.parse(callSync(obj.deny, obj, '{}'))
+    assert.deepEqual(payload, {
+      code: -1,
+      errMsg: JSON.stringify(err)
+    })
+  })
+
+  it('handlerError keeps code -1 and stringifies the CallResult', () => {
+    const result = { code: -1 }
+    const raw = handlerError(result, '{"message":"native failed"}')
+    assert.equal(raw, JSON.stringify({
+      code: -1,
+      errMsg: '{"message":"native failed"}'
+    }))
+  })
+
+  it('does not leak the exception to the caller (WebView/JS crash path)', () => {
+    const obj = {
+      crash() {
+        throw new Error('should stay inside the bridge')
+      }
+    }
+    let escaped = false
+    let raw
+    try {
+      raw = callSync(obj.crash, obj, '{"data":1}')
+    } catch {
+      escaped = true
+    }
+    assert.equal(escaped, false)
+    assert.equal(typeof raw, 'string')
+    const payload = JSON.parse(raw)
+    assert.equal(payload.code, -1)
+    assert.ok(typeof payload.errMsg === 'string' && payload.errMsg.length > 0)
+  })
+})


### PR DESCRIPTION
Sync call() invoked method.call without try/catch, so a @JavaScriptInterface throw escaped the bridge. Async already used handlerError; wrap sync the same way.

Host test: node --test test/syncCallHelper.test.mjs. No device.

Signed-off-by: Tony Coder <407243179@qq.com>