### PR TITLE
fix: keep independent callback ids for concurrent async calls

### DIFF
--- a/entry/src/main/resources/rawfile/dsBridge3.0.js
+++ b/entry/src/main/resources/rawfile/dsBridge3.0.js
@@ -1,12 +1,12 @@
 // @ts-nocheck
+// Isolated call-id. Do not use window.callID — H5 pages reuse that name
+// and overlapping async calls then share/overwrite the same dscallN stub.
+let _dsbCallId = 0
 const bridge = {
     call: function (method, args, callback) {
         let params = {data: args === undefined ? null : args}
         if (callback != null && typeof callback == 'function') {
-            if (!window.callID) {
-                window.callID = 0
-            }
-            const callName = "dscall" + (window.callID++)
+            const callName = "dscall" + (_dsbCallId++)
             window[callName] = callback
             params["_dscbstub"] = callName
         }

--- a/entry/src/main/resources/rawfile/dsbridge2.0.js
+++ b/entry/src/main/resources/rawfile/dsbridge2.0.js
@@ -1,5 +1,8 @@
 function getJsBridge() {
     window._dsf = window._dsf || {};
+    // Isolated call-id. Do not use a page-owned window.dscb / window.callID
+    // counter — overlapping async calls would then reuse the same stub.
+    var dscb = 0;
     return {
         call: function (method, args, cb) {
             var ret = "";
@@ -8,8 +11,7 @@ function getJsBridge() {
                 args = {}
             }
             if (typeof cb == "function") {
-                window.dscb = window.dscb || 0;
-                var cbName = "dscb" + window.dscb++;
+                var cbName = "dscb" + dscb++;
                 window[cbName] = cb;
                 args["_dscbstub"] = cbName
             }

--- a/library/src/main/ets/core/BaseBridge.ts
+++ b/library/src/main/ets/core/BaseBridge.ts
@@ -9,7 +9,6 @@ import {
   CompleteHandler,
   JavaScriptInterface,
   OnCloseWindowListener,
-  Args,
   OnErrorMessageListener,
   NativeMethodParam,
   OnPageClose
@@ -19,6 +18,7 @@ import { LogUtils } from '../utils/LogUtils'
 import router from '@ohos.router'
 import { IBaseBridge, IWebViewControllerProxy } from './WebViewInterface'
 import { ToastUtils } from '../utils/ToastUtils'
+import { createAsyncCompleteHandler } from '../utils/AsyncCallbackHelper'
 import { JSON } from '@kit.ArkTS'
 
 export class BaseBridge implements JsInterface, IBaseBridge {
@@ -156,19 +156,13 @@ export class BaseBridge implements JsInterface, IBaseBridge {
 
     }
     if (async) {
-      const handler = <CompleteHandler> {
-        complete: (value: Args) => {
-          result.code = 0
-          result.data = value
-          this.callbackToJs(jsParam, result)
-        },
-        setProgressData: (value: Args) => {
-          result.code = 0
-          result.data = value
-          this.callbackToJs(jsParam, result, false)
-        },
-
-      }
+      // Capture stub now and snapshot a fresh payload per complete().
+      // Do not mutate `result` or re-read jsParam._dscbstub — parallel
+      // calls would then share a last-result slot or overwrite each other.
+      const callbackStub = jsParam._dscbstub
+      const handler = <CompleteHandler> createAsyncCompleteHandler(callbackStub, (script) => {
+        this.dispatchAsyncCallback(script)
+      })
       try {
         let len = method.length
 
@@ -236,15 +230,9 @@ export class BaseBridge implements JsInterface, IBaseBridge {
 
   }
 
-  private callbackToJs = (jsParam: Parameter, result: CallResult, complete: boolean = true) => {
+  private dispatchAsyncCallback = (script: string) => {
     if (this.interrupt) return;
-    let args = JSON.stringify(result)
-    let callbackName = jsParam._dscbstub
-    LogUtils.d(`callbackToJs : ${callbackName}(${args})`)
-    let script = `${callbackName}(${args}.data);`
-    if (complete) {
-      script += "delete window." + callbackName
-    }
+    LogUtils.d(`callbackToJs : ${script}`)
     this.controller.runJavaScript(script)
   }
 
@@ -407,7 +395,7 @@ export class BaseBridge implements JsInterface, IBaseBridge {
   injectDS2Js(){
     if (this._isSupportDS2 && !this.isDS2Injected) {
       let script =
-        "function getJsBridge(){window._dsf=window._dsf||{};return{call:function(b,a,c){\"function\"==typeof a&&(c=a,a={});if(\"function\"==typeof c){window.dscb=window.dscb||0;var d=\"dscb\"+window.dscb++;window[d]=c;a._dscbstub=d}a=JSON.stringify(a||{});return window._dswk?prompt(window._dswk+b,a):\"function\"==typeof _dsbridge?_dsbridge(b,a):_dsbridge.call(b,a)},register:function(b,a){\"object\"==typeof b?Object.assign(window._dsf,b):window._dsf[b]=a}}}dsBridge=getJsBridge();"
+        "function getJsBridge(){window._dsf=window._dsf||{};var e=0;return{call:function(b,a,c){\"function\"==typeof a&&(c=a,a={});if(\"function\"==typeof c){var d=\"dscb\"+e++;window[d]=c;a._dscbstub=d}a=JSON.stringify(a||{});return window._dswk?prompt(window._dswk+b,a):\"function\"==typeof _dsbridge?_dsbridge(b,a):_dsbridge.call(b,a)},register:function(b,a){\"object\"==typeof b?Object.assign(window._dsf,b):window._dsf[b]=a}}}dsBridge=getJsBridge();"
        this.controller.runJavaScript(script)
       // 完成DS2.0脚本的注入
       this.isDS2Injected = true

--- a/library/src/main/ets/utils/AsyncCallbackHelper.ts
+++ b/library/src/main/ets/utils/AsyncCallbackHelper.ts
@@ -1,0 +1,79 @@
+/**
+ * Concurrent H5 → native async callbacks.
+ *
+ * BaseBridge.call() used to close over one CallResult and re-read
+ * jsParam._dscbstub in complete(). Parallel calls then shared a last-result
+ * slot or the latest stub. Android DSBridge snapshots a fresh JSONObject and
+ * a final callback name per complete().
+ */
+
+export interface AsyncCallbackPayload {
+  code: number
+  data?: Object | string | number | boolean
+}
+
+export type AsyncCallbackValue = Object | string | number | boolean
+
+export type AsyncScriptRunner = (script: string) => void
+
+/**
+ * Build the JS snippet for one async completion. Fresh payload every time;
+ * never mutate call()'s result object.
+ */
+export function buildAsyncCallbackScript(
+  callbackStub: string | undefined,
+  value: AsyncCallbackValue,
+  complete: boolean = true
+): string | undefined {
+  if (!callbackStub) {
+    return undefined
+  }
+  const payload: AsyncCallbackPayload = { code: 0, data: value }
+  const args = JSON.stringify(payload)
+  let script = `${callbackStub}(${args}.data);`
+  if (complete) {
+    script += "delete window." + callbackStub
+  }
+  return script
+}
+
+/**
+ * CompleteHandler whose stub is captured at call time.
+ * complete() / setProgressData() each snapshot an independent payload.
+ */
+export function createAsyncCompleteHandler(
+  callbackStub: string | undefined,
+  runScript: AsyncScriptRunner
+): { complete: (value: AsyncCallbackValue) => void, setProgressData: (value: AsyncCallbackValue) => void } {
+  return {
+    complete: (value: AsyncCallbackValue) => {
+      const script = buildAsyncCallbackScript(callbackStub, value, true)
+      if (script) {
+        runScript(script)
+      }
+    },
+    setProgressData: (value: AsyncCallbackValue) => {
+      const script = buildAsyncCallbackScript(callbackStub, value, false)
+      if (script) {
+        runScript(script)
+      }
+    }
+  }
+}
+
+export interface DsCallbackIdState {
+  callId: number
+}
+
+/**
+ * Isolated H5 callback-id allocator.
+ * Do not use window.callID — pages reuse that name and collide dscallN stubs.
+ */
+export function nextDsCallbackStub(
+  state: DsCallbackIdState,
+  prefix: string = 'dscall'
+): string {
+  const id = state.callId
+  state.callId = id + 1
+  return prefix + id
+}

--- a/test/asyncCallbackHelper.mjs
+++ b/test/asyncCallbackHelper.mjs
@@ -1,0 +1,71 @@
+/**
+ * Extracted host-side helper mirroring
+ * library/src/main/ets/utils/AsyncCallbackHelper.ts
+ *
+ * Concurrent H5 → native async calls must keep independent callback stubs
+ * and result snapshots. Do not mutate call()'s last-result object or re-read
+ * jsParam._dscbstub at complete() time.
+ */
+
+export function buildAsyncCallbackScript(callbackStub, value, complete = true) {
+  if (!callbackStub) {
+    return undefined
+  }
+  const payload = { code: 0, data: value }
+  const args = JSON.stringify(payload)
+  let script = `${callbackStub}(${args}.data);`
+  if (complete) {
+    script += "delete window." + callbackStub
+  }
+  return script
+}
+
+export function createAsyncCompleteHandler(callbackStub, runScript) {
+  return {
+    complete(value) {
+      const script = buildAsyncCallbackScript(callbackStub, value, true)
+      if (script) {
+        runScript(script)
+      }
+    },
+    setProgressData(value) {
+      const script = buildAsyncCallbackScript(callbackStub, value, false)
+      if (script) {
+        runScript(script)
+      }
+    }
+  }
+}
+
+/**
+ * Mirrors BaseBridge.call() async branch after the method is resolved:
+ * capture _dscbstub now, give the native method its own handler.
+ */
+export function dispatchAsyncNativeCall(jsParam, method, obj, runScript) {
+  const callbackStub = jsParam._dscbstub
+  const handler = createAsyncCompleteHandler(callbackStub, runScript)
+  const data = jsParam.data
+  method.call(obj, data, handler)
+}
+
+/**
+ * Isolated H5 callback-id allocator (dsBridge 3.0).
+ * Must not read or write window.callID.
+ */
+export function nextDsCallbackStub(state, prefix = 'dscall') {
+  const id = state.callId
+  state.callId = id + 1
+  return prefix + id
+}
+
+/**
+ * Legacy DS3 allocator: window.callID + falsy reset.
+ * Concurrent / page-owned callID reuse collides stubs.
+ */
+export function allocLegacyWindowCallIdStub(win) {
+  if (!win.callID) {
+    win.callID = 0
+  }
+  const callName = 'dscall' + (win.callID++)
+  return callName
+}

--- a/test/asyncCallbackHelper.test.mjs
+++ b/test/asyncCallbackHelper.test.mjs
@@ -1,0 +1,150 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildAsyncCallbackScript,
+  createAsyncCompleteHandler,
+  dispatchAsyncNativeCall,
+  nextDsCallbackStub,
+  allocLegacyWindowCallIdStub
+} from './asyncCallbackHelper.mjs'
+
+function parseCallbackScript(script) {
+  const match = script.match(/^(dscall\d+)\((\{.*\})\.data\);(delete window\.(dscall\d+))?$/)
+  assert.ok(match, `unexpected script: ${script}`)
+  const stub = match[1]
+  const payload = JSON.parse(match[2])
+  const deleted = match[4] ?? null
+  return { stub, payload, deleted }
+}
+
+describe('concurrent async native callbacks', () => {
+  it('keeps independent stubs and results for 6 out-of-order completions', () => {
+    const pending = []
+    const api = {
+      fetch(data, handler) {
+        pending.push({ data, handler })
+      }
+    }
+    const scripts = []
+    const runScript = (script) => scripts.push(script)
+
+    for (let i = 0; i < 6; i++) {
+      dispatchAsyncNativeCall(
+        { data: { req: i }, _dscbstub: `dscall${i}` },
+        api.fetch,
+        api,
+        runScript
+      )
+    }
+    assert.equal(pending.length, 6)
+
+    const order = [3, 0, 5, 1, 4, 2]
+    for (const i of order) {
+      pending[i].handler.complete({ req: i, body: `res-${i}` })
+    }
+
+    assert.equal(scripts.length, 6)
+    const seen = new Set()
+    for (const script of scripts) {
+      const { stub, payload, deleted } = parseCallbackScript(script)
+      const req = payload.data.req
+      assert.equal(stub, `dscall${req}`)
+      assert.equal(payload.code, 0)
+      assert.deepEqual(payload.data, { req, body: `res-${req}` })
+      assert.equal(deleted, stub)
+      assert.equal(seen.has(stub), false)
+      seen.add(stub)
+    }
+    assert.equal(seen.size, 6)
+  })
+
+  it('captures _dscbstub at call time so later jsParam mutation cannot retarget', () => {
+    const scripts = []
+    const jsParam = { data: 'a', _dscbstub: 'dscall0' }
+    const handler = createAsyncCompleteHandler(jsParam._dscbstub, (s) => scripts.push(s))
+
+    jsParam._dscbstub = 'dscall1'
+    handler.complete('value-for-0')
+
+    assert.equal(scripts.length, 1)
+    const { stub, payload } = parseCallbackScript(scripts[0])
+    assert.equal(stub, 'dscall0')
+    assert.equal(payload.data, 'value-for-0')
+  })
+
+  it('does not mutate a shared last-result slot when completing in parallel', () => {
+    const lastResult = { code: -1, data: 'stale' }
+    const scripts = []
+    const a = createAsyncCompleteHandler('dscall0', (s) => scripts.push(s))
+    const b = createAsyncCompleteHandler('dscall1', (s) => scripts.push(s))
+
+    a.complete({ id: 'A' })
+    b.complete({ id: 'B' })
+
+    assert.deepEqual(lastResult, { code: -1, data: 'stale' })
+    assert.equal(parseCallbackScript(scripts[0]).payload.data.id, 'A')
+    assert.equal(parseCallbackScript(scripts[1]).payload.data.id, 'B')
+    assert.notEqual(parseCallbackScript(scripts[0]).payload, parseCallbackScript(scripts[1]).payload)
+  })
+
+  it('setProgressData keeps the stub; complete deletes it', () => {
+    const scripts = []
+    const handler = createAsyncCompleteHandler('dscall2', (s) => scripts.push(s))
+    handler.setProgressData('p1')
+    handler.setProgressData('p2')
+    handler.complete('done')
+
+    assert.equal(scripts.length, 3)
+    const p1 = parseCallbackScript(scripts[0])
+    const p2 = parseCallbackScript(scripts[1])
+    const done = parseCallbackScript(scripts[2])
+    assert.equal(p1.stub, 'dscall2')
+    assert.equal(p1.payload.data, 'p1')
+    assert.equal(p1.deleted, null)
+    assert.equal(p2.payload.data, 'p2')
+    assert.equal(p2.deleted, null)
+    assert.equal(done.payload.data, 'done')
+    assert.equal(done.deleted, 'dscall2')
+  })
+
+  it('does not dispatch JS when H5 omitted a callback stub', () => {
+    let ran = false
+    const handler = createAsyncCompleteHandler(undefined, () => {
+      ran = true
+    })
+    handler.complete('x')
+    handler.setProgressData('y')
+    assert.equal(ran, false)
+    assert.equal(buildAsyncCallbackScript(undefined, 'x'), undefined)
+    assert.equal(buildAsyncCallbackScript('', 'x'), undefined)
+  })
+})
+
+describe('H5 callback-id allocator', () => {
+  it('issues unique stubs for 6 rapid allocations', () => {
+    const state = { callId: 0 }
+    const stubs = []
+    for (let i = 0; i < 6; i++) {
+      stubs.push(nextDsCallbackStub(state))
+    }
+    assert.deepEqual(stubs, ['dscall0', 'dscall1', 'dscall2', 'dscall3', 'dscall4', 'dscall5'])
+    assert.equal(state.callId, 6)
+    assert.equal(new Set(stubs).size, 6)
+  })
+
+  it('does not collide when window.callID is reset or reused by the page', () => {
+    const win = { callID: 0 }
+    const state = { callId: 0 }
+    const isolated = []
+    const legacy = []
+    for (let i = 0; i < 6; i++) {
+      win.callID = 0
+      isolated.push(nextDsCallbackStub(state))
+      legacy.push(allocLegacyWindowCallIdStub(win))
+    }
+    assert.equal(new Set(isolated).size, 6)
+    assert.equal(new Set(legacy).size, 1)
+    assert.equal(legacy[0], 'dscall0')
+    assert.equal(legacy[5], 'dscall0')
+  })
+})


### PR DESCRIPTION
Fixes #29.

H5 firing the same native async method several times in parallel mixed up results: complete() re-read jsParam._dscbstub / last result. Snapshot the callback stub per call and use a per-bridge callback id allocator so concurrent calls stay independent.

Host tests: test/asyncCallbackHelper.test.mjs. No device.

Signed-off-by: Tony Coder <407243179@qq.com>